### PR TITLE
Switch to GTK3 to fix layout tab crashes

### DIFF
--- a/Recipe.deps
+++ b/Recipe.deps
@@ -1,5 +1,5 @@
 apt-get update
-apt-get install -y --force-yes g++ gcc build-essential libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev freeglut3-dev libavcodec-dev libavformat-dev libswscale-dev libsdl2-dev libswresample-dev libavutil-dev libavresample-dev libportmidi-dev libzstd-dev libcurl4-openssl-dev wget git fuse gpgv colormake
+apt-get install -y --force-yes g++ gcc build-essential libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev freeglut3-dev libavcodec-dev libavformat-dev libswscale-dev libsdl2-dev libswresample-dev libavutil-dev libavresample-dev libportmidi-dev libzstd-dev libcurl4-openssl-dev wget git fuse gpgv colormake
 apt-get clean
 
 # Build wxwidgets
@@ -11,7 +11,7 @@ rm wxWidgets-3.1.3.tar.bz2
 cd wxWidgets-3.1.3
 patch -p1 < ../wxwidgets-31.patch
 rm ../wxwidgets-31.patch
-CXXFLAGS="-std=gnu++14" ./configure --enable-cxx11 --enable-std_containers --enable-std_string --enable-std_string_conv_in_wxstring --enable-backtrace --enable-exceptions --enable-mediactrl --enable-graphics_ctx --enable-shared --disable-gtktest --disable-sdltest --with-gtk=2 --disable-pcx --disable-iff --without-libtiff --prefix=/usr
+CXXFLAGS="-std=gnu++14" ./configure --enable-cxx11 --enable-std_containers --enable-std_string --enable-std_string_conv_in_wxstring --enable-backtrace --enable-exceptions --enable-mediactrl --enable-graphics_ctx --enable-shared --disable-gtktest --disable-sdltest --with-gtk=3 --disable-pcx --disable-iff --without-libtiff --prefix=/usr
 make -j 4
 make install PREFIX=/usr
 cd ..


### PR DESCRIPTION
Something in wxWidgets 3.1.3 really doesn't like GTK2 - Large swathes of
heap corruption and the like. The GTK3 version seems much happier.

Basic testing performed - Opened xLights AppImage build, checked I could manipulate the layout and create and play a basic sequence.