### PR TITLE
fix: remove offending configure option for wxWidgets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get clean
 RUN cd / && \
     git clone --depth=1 --shallow-submodules  --recurse-submodules -b xlights_2023.11 https://github.com/xLightsSequencer/wxWidgets xlights_2023.11 && \
     cd xlights_2023.11 && \
-    ./configure --with-cxx=17 --enable-std_containers --enable-std_string --enable-std_string_conv_in_wxstring --enable-backtrace --enable-exceptions --enable-mediactrl --enable-graphics_ctx --enable-shared --disable-gtktest --disable-sdltest --with-gtk=3 --disable-pcx --disable-iff --without-libtiff --prefix=/usr && \
+    ./configure --with-cxx=17 --enable-std_containers --enable-std_string_conv_in_wxstring --enable-backtrace --enable-exceptions --enable-mediactrl --enable-graphics_ctx --enable-shared --disable-gtktest --disable-sdltest --with-gtk=3 --disable-pcx --disable-iff --without-libtiff --prefix=/usr && \
     make -j 4 && \
     make install PREFIX=/usr && \
     cd .. && \


### PR DESCRIPTION
Looks like it got removed in https://github.com/wxWidgets/wxWidgets/commit/be7860c7661756e8de36985ade760d5c9a784ab7 and must have broken this build when the updates were pulled in: https://github.com/xLightsSequencer/xlights-build-docker/commit/c63e072b28871b58d8a5f07fc924a2a03b3a566f 

Testing the build container locally seems to work as intended and allows the app image to be built. 

Should fix: https://github.com/smeighan/xLights/issues/4131 for the release once `debenham/xlights` is updated. I think the `docker build` was masking the underlying issue and had to build manually. 